### PR TITLE
feat: Interface DNS config

### DIFF
--- a/models.py
+++ b/models.py
@@ -16,6 +16,7 @@ class InterfaceModel(BaseModel):
     Address: IPv4Interface | None = None
     PrivateKey: str | None = None
     ListenPort: int | None = None
+    DNS: str | None = None # Has to be in the Wireguard conf format. For example: "1.1.1.1, 8.8.8.8"
 
 
 class PeerModel(BaseModel):
@@ -39,6 +40,7 @@ class HostModel(BaseModel):
 class DynamicHost(BaseModel):
     StartIP: IPv4Address
     PrefixLen: int
+    DNS: list[IPv4Address] | None = None
 
 
 class YamlConfig(BaseModel):

--- a/parseyamlconfig.py
+++ b/parseyamlconfig.py
@@ -69,6 +69,10 @@ def parse_yaml_config(yaml_contents: dict):
             keypair = gen_keypair()
             ifdata.Interface.PrivateKey = keypair.private
             ifdata.Peer.PublicKey = keypair.public
+        # Create Interface DNS config
+        if not ifdata.Interface.DNS:
+            if cfgdata.Dynamic.DNS:
+                ifdata.Interface.DNS = ",".join(str(ip) for ip in cfgdata.Dynamic.DNS)
 
     raw_cfgdata = cfgdata.model_dump(mode='json', exclude_none=True)
     # pprint(raw_cfgdata)


### PR DESCRIPTION
Can be either set as a string in the Machine Interface settings

```yaml
Machines:
  # Server peers need a publicly accessible Endpoint
  Router:
    Interface:
      Address: 192.168.100.1
      ListenPort: 51820
      DNS: "8.8.8.8,1.1.1.1"
```
... or inherited from the Dynamic block


```yaml
Dynamic:
  StartIP: 192.168.100.2
  PrefixLen: 24
  DNS:
    - 192.168.0.1
    - 192.168.0.2
```

If both exist, the Machine-specific DNS takes precedence

DNS must be specified differently:
* Machine Specific:  Must be a sting like "8.8.8.8,1.1.1.1" which is Wireguard config compatible.
* Dynamic: Must be a list of IPv4 Addresses