### PR TITLE
fix: PSK comments

### DIFF
--- a/parseyamlconfig.py
+++ b/parseyamlconfig.py
@@ -75,14 +75,13 @@ def parse_yaml_config(yaml_contents: dict):
         if UNIPSK not in cfgdata.PresharedKeyPairs:
             cfgdata.PresharedKeyPairs[UNIPSK] = gen_psk()
     else:
-        # This gets us a list of tuples with unique machine combinations. For example:
-        # [(Router, Client1), (Router, Client2), (Client1, Client2)]
+        # This gets us a list of strings with unique machine combinations.
+        # Each pair is sorted alphabetically. For example:
+        # ["Client1,Router", "Client2,Router", "Client1,Client2"]
         unique_machine_pairs = map(
-            ','.join, sorted(combinations(cfgdata.Machines.keys(), 2))
+            ','.join, map(sorted, combinations(cfgdata.Machines.keys(), 2))
         )
 
-        # After we get the unique pairing list, we can then build a dict with a distinct PSK per unique pair. Example:
-        # { (Router, Client1): "psk1...", (Router, Client2): "psk2...", (Client1, Client2): "psk3..."}
         for pair in unique_machine_pairs:
             if pair not in cfgdata.PresharedKeyPairs:
                 cfgdata.PresharedKeyPairs[pair] = gen_psk()


### PR DESCRIPTION
Without this fix, we don't properly sort pairs

The easiest way to reproduce (prior to this PR) is to have a config like this:

```yaml
Dynamic:
  StartIP: 192.168.0.2
  PrefixLen: 24
# Defined machines
Machines:
  # Server peers need a publicly accessible Endpoint
  ZZZMachine:
    Interface:
      Address: 192.168.0.1
      ListenPort: 51820
    Peer:
      Endpoint:  endpoint.example.com:51820
      PersistentKeepalive: 25
  AAAMachine: {}
```

Output:

```plain
Traceback (most recent call last):
  File "/home/milos/git/wireguard-config-gen/run.py", line 16, in <module>
    parse_yaml_config(yaml_contents)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/milos/git/wireguard-config-gen/parseyamlconfig.py", line 95, in parse_yaml_config
    wgconf = parse_to_wg_config(ifname, cfgdata)
  File "/home/milos/git/wireguard-config-gen/parsewgconfig.py", line 26, in parse_to_wg_config
    wgconf.Peers[ifname].PresharedKey = ymlconfig.PresharedKeyPairs[
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        ','.join(sorted((ifname, machine_name)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ]
    ^
KeyError: 'AAAMachine,ZZZMachine'
```