### PR TITLE
Specify star or mesh topology

### DIFF
--- a/interfaces.demo.yaml
+++ b/interfaces.demo.yaml
@@ -26,4 +26,7 @@ Machines:
 PresharedKeyPairs: {}
 # Use the same PSK on all peers for debugging purposes. False by default
 UseUniversalPSK: false
+# The output folder for the final Wireguard conf files
 Outdir: output/
+# Specify star or mesh topology
+Topology: star

--- a/models.py
+++ b/models.py
@@ -7,8 +7,16 @@ HostName = str
 
 
 class TopologyType(Enum):
-    mesh = 'mesh'  # Any peer can reach any other peer
-    star = 'star'  # Client peers can only reach Server peers, Server peers can reach any other peer
+    """
+    In mesh mode:
+        Any peer can reach any other peer.
+    In star mode:
+        Client peers can only reach Server peers (via the public endpoint).
+        Server peers can receive from any other peer.
+    """
+
+    mesh = 'mesh'
+    star = 'star'
 
 
 class Keypair(BaseModel):

--- a/models.py
+++ b/models.py
@@ -13,6 +13,7 @@ class TopologyType(Enum):
     In star mode:
         Client peers can only reach Server peers (via the public endpoint).
         Server peers can receive from any other peer.
+    The default is star mode.
     """
 
     mesh = 'mesh'

--- a/models.py
+++ b/models.py
@@ -59,7 +59,7 @@ class YamlConfig(BaseModel):
     PresharedKeyPairs: dict[str, str] = dict()
     UseUniversalPSK: bool = False
     Outdir: str = 'output/'
-    Topology: TopologyType = TopologyType.mesh
+    Topology: TopologyType = TopologyType.star
 
 
 class WireguardConfig(BaseModel):

--- a/models.py
+++ b/models.py
@@ -1,8 +1,14 @@
+from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface
 
 from pydantic import BaseModel
 
 HostName = str
+
+
+class TopologyType(Enum):
+    mesh = 'mesh'  # Any peer can reach any other peer
+    star = 'star'  # Client peers can only reach Server peers, Server peers can receive from any Client peer
 
 
 class Keypair(BaseModel):
@@ -53,6 +59,7 @@ class YamlConfig(BaseModel):
     PresharedKeyPairs: dict[str, str] = dict()
     UseUniversalPSK: bool = False
     Outdir: str = 'output/'
+    Topology: TopologyType = TopologyType.mesh
 
 
 class WireguardConfig(BaseModel):

--- a/models.py
+++ b/models.py
@@ -8,7 +8,7 @@ HostName = str
 
 class TopologyType(Enum):
     mesh = 'mesh'  # Any peer can reach any other peer
-    star = 'star'  # Client peers can only reach Server peers, Server peers can receive from any Client peer
+    star = 'star'  # Client peers can only reach Server peers, Server peers can reach any other peer
 
 
 class Keypair(BaseModel):
@@ -68,4 +68,4 @@ class WireguardConfig(BaseModel):
     """
 
     Interface: InterfaceModel
-    Peers: dict[str, PeerModel] = dict()
+    Peers: dict[HostName, PeerModel] = dict()

--- a/parsewgconfig.py
+++ b/parsewgconfig.py
@@ -14,7 +14,7 @@ def parse_to_wg_config(machine_name: str, ymlconfig: YamlConfig) -> WireguardCon
     this_peer = ymlconfig.Machines[machine_name].Peer
     wgconf = WireguardConfig(Interface=this_interface)
 
-    # Mesh topology is the default, which is many to many
+    # Start with the mesh topology, which is many to many
     machine_items = ymlconfig.Machines.items()
     # Only include Server peers for star topology Clients
     if ymlconfig.Topology == TopologyType.star and not this_peer.Endpoint:

--- a/parsewgconfig.py
+++ b/parsewgconfig.py
@@ -1,5 +1,4 @@
-from pprint import pprint
-
+# from pprint import pprint
 from models import TopologyType, WireguardConfig, YamlConfig
 from utils import now, parse_version
 
@@ -31,7 +30,7 @@ def parse_to_wg_config(machine_name: str, ymlconfig: YamlConfig) -> WireguardCon
                     ','.join(sorted((ifname, machine_name)))
                 ]
 
-    pprint(wgconf.model_dump(mode='json', exclude_none=True))
+    # pprint(wgconf.model_dump(mode='json', exclude_none=True))
     return wgconf
 
 


### PR DESCRIPTION
In mesh mode:
 - Any peer can reach any other peer.

In star mode:
 - Client peers can only reach Server peers (via the public endpoint).
 - Server peers can receive from any other peer.

The default is star mode.

cc @Kaurin 